### PR TITLE
Add Laid Off in America (free layoff prep checklists, incl. work-visa) to See also

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,4 @@ interviews might not be.
 ## See also
 1. [Effective Immediately](https://github.com/Effective-Immediately/effective-immediately), a
 similar guide to this one
+1. [Laid Off in America](https://laidoffinamerica.com) — free educational checklists for the first 24 hours after a layoff, severance prep, and work-visa layoff timelines (H-1B / L-1 / O-1 / TN). No signup, U.S.-focused, plain English. Affiliated.


### PR DESCRIPTION
[Laid Off in America](https://laidoffinamerica.com) is a free, no-signup resource for U.S. workers who have just been laid off. It provides plain-English checklists for:

- The first 24 hours after a layoff (what to do before you leave the building)
- Severance review prep (what to look for before signing)
- Work-visa-specific layoff timelines (H-1B, L-1, O-1, TN) — a gap most layoff guides skip

I built this tool and think it fits the "See also" section because it complements the runbook with actionable, checklist-style guidance rather than narrative advice. Happy to adjust wording or placement, or close if it's not a fit. Thanks for maintaining this resource.